### PR TITLE
Fix typo #4 yay -S cmus-rpc-rs-rs -> yay -S cmus-rpc-rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     ```bash
     crago install cmus-rpc-rs 
     ```
-- From aur: `yay -S cmus-rpc-rs-rs`
+- From aur: `yay -S cmus-rpc-rs`
 
 
 ### Options:


### PR DESCRIPTION
Fix the typo in the AUR install command in the readme file #4 